### PR TITLE
parse config in ini format

### DIFF
--- a/wgnetns/main.py
+++ b/wgnetns/main.py
@@ -225,12 +225,12 @@ class Namespace:
                 # TODO refactor the internal config
                 # to use the same config format as wg-quick
                 config_map = [
-                    (('Interface', 'Address'),        ('interfaces', 0, 'address')),
+                    (('Interface', 'Address'),        ('interfaces', 0, 'address', 0)),
                     (('Interface', 'PrivateKey'),     ('interfaces', 0, 'private_key')),
                     (('Interface', 'DNS'),            ('dns_server', 0)),
                     (('Peer', 'PersistentKeepalive'), ('interfaces', 0, 'peers', 0, 'persistent_keepalive')),
                     (('Peer', 'PublicKey'),           ('interfaces', 0, 'peers', 0, 'public_key')),
-                    (('Peer', 'AllowedIPs'),          ('interfaces', 0, 'peers', 0, 'allowed_ips')),
+                    (('Peer', 'AllowedIPs'),          ('interfaces', 0, 'peers', 0, 'allowed_ips', 0)),
                     (('Peer', 'Endpoint'),            ('interfaces', 0, 'peers', 0, 'endpoint')),
                 ]
 
@@ -241,10 +241,13 @@ class Namespace:
                 if 'Interface' in raw_config:
                     config['interfaces'] = [dict()]
                     config['interfaces'][0]['name'] = profile_name
+                    config['interfaces'][0]['address'] = ['']
                     if 'DNS' in raw_config['Interface']:
                         config['dns_server'] = ['']
                 if 'Peer' in raw_config:
                     config['interfaces'][0]['peers'] = [dict()]
+                    if 'AllowedIPs' in raw_config['Peer']:
+                        config['interfaces'][0]['peers'][0]['allowed_ips'] = ['']
 
                 def get(obj, path):
                     res = obj
@@ -260,10 +263,12 @@ class Namespace:
                     parent[key] = value
 
                 for (get_path, set_path) in config_map:
-                    # TODO try ...
-                    val = get(raw_config, get_path)
-                    #print(f"get_path {get_path} -> val {val} -> set_path {set_path}")
-                    set(config, set_path, val)
+                    try:
+                        #print(f"get_path {get_path} -> val {val} -> set_path {set_path}")
+                        val = get(raw_config, get_path)
+                        set(config, set_path, val)
+                    except KeyError:
+                        pass
 
                 #print(f"config {config}")
 


### PR DESCRIPTION
fix #3 

i tried to use this from my [python-piavpn](https://github.com/milahu/python-piavpn)
using `wg-netns` as a drop-in replacement for `wg-quick`

... but DNS is broken

```
sudo ./piavpn.py -c /etc/piavpn.config.yaml
...
exec: sudo ip netns exec pia curl --no-progress-meter 'https://api64.ipify.org?format=json'
curl: (7) Couldn't connect to server

sudo cat /etc/netns/pia/resolv.conf 
nameserver 10.0.0.243

ip netns list
pia (id: 0)
```

the DNS server is reachable only over VPN
the second ping should work:

```
ping 10.0.0.243
PING 10.0.0.243 (10.0.0.243) 56(84) bytes of data.
From 62.155.242.79 icmp_seq=1 Destination Net Unreachable

sudo ip netns exec pia ping 10.0.0.243
ping: connect: Network is unreachable
```
