### PR TITLE
Add support for more complex post-up and friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,15 @@ name: ns-example
 managed: true
 # list of dns servers, if empty dns servers from default netns will be used
 dns-server: [10.10.10.1, 10.10.10.2]
-# shell hooks, e.g. to set firewall rules
-pre-up: echo pre-up
-post-up: echo post-up
-pre-own: echo pre-down
-post-down: echo post-down
+# shell hooks, e.g. to set firewall rules, two formats are supported
+pre-up: echo pre-up from managed netns
+post-up:
+- host-namespace: true
+  command: echo post-up from host netns
+- host-namespace: false
+  command: echo post-up from managed netns
+pre-down: echo pre-down from managed netns
+post-down: echo post-down from managed netns
 # list of wireguard interfaces inside the netns
 interfaces:
   # interface name, required


### PR DESCRIPTION
This merge request turns `pre-up`, `post-up`, `pre-down`, and `post-down` into &ldquo;scriptlets,&rdquo; which can have a more complex shape than just a command string.

The explicit form is now

```yaml
post-up:
  - host-namespace: true  # or false
    command: echo 'Hello world'  # Command string passed to sh -c
  # Multiple items are allowed and are run in sequence
  - host-namespace: false
    command: echo 'Hello again'
```

There are multiple shorthand forms:

```yaml
post-up:
  - command: echo foo  # Defaults to running in the created namespace
  - echo bar  # A bare string also runs in the created namespace
```

```yaml
post-up:
  host-namespace: true  # A single command can be specified without a list
  command: echo blah
```

And we can still use a single bare string as before

```yaml
post-up: echo 'Same as ever'  # Runs in the created namespace
```

Closes #6 