### PR TITLE
Add base_netns functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Full YAML example:
 ~~~ yaml
 # name of the network namespace
 name: ns-example
+# namespace where the interface is initialized, defaults to the main/default namespace
+base_netns: null
 # if false, the netns itself won't be created or deleted, just the interfaces inside it
 managed: true
 # list of dns servers, if empty dns servers from default netns will be used


### PR DESCRIPTION
An option is added to specify the namespace in which the Wireguard interface will be originally created, i.e. the namespace from which we route to the Wireguard server. This is useful if a Wireguard server is only accessible behind another Wireguard VPN, or to potentially improve privacy. 

I tested it with two servers stacked into each other and it worked flawlessly. Note that it might be necessary to adjust the MTU when stacking multiple VPNs, as each incurs some overhead.