### PR TITLE
Change private-key to an optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ interfaces:
   address:
   - 10.10.11.172/32
   - fc00:dead:beef:1::172/128
+  # can also be set via "wg set wg-site-a $key"
   private-key: nFkQQjN+...
   # optional settings
   listen-port: 51821

--- a/wgnetns/main.py
+++ b/wgnetns/main.py
@@ -135,7 +135,7 @@ class Peer:
 class Interface:
     name: str
     base_netns: str
-    private_key: str
+    private_key: Optional[str] = None
     public_key: Optional[str] = None
     address: list[str] = dataclasses.field(default_factory=list)
     listen_port: int = 0
@@ -166,7 +166,8 @@ class Interface:
     def _configure_wireguard(self, namespace: Namespace) -> None:
         wg('set', self.name, 'listen-port', self.listen_port, netns=namespace.name)
         wg('set', self.name, 'fwmark', self.fwmark, netns=namespace.name)
-        wg('set', self.name, 'private-key', '/dev/stdin', stdin=self.private_key, netns=namespace.name)
+        if self.private_key:
+            wg('set', self.name, 'private-key', '/dev/stdin', stdin=self.private_key, netns=namespace.name)
 
     def _assign_addresses(self, namespace: Namespace) -> None:
         for address in self.address:


### PR DESCRIPTION
This allows private keys to be left out of config files and allows config files to be world-readable.

A common pattern is for the private key to be set in a post-up command. This is described in the wg-quick(8) manual page:

```
Or, perhaps it is desirable to store private keys in encrypted form, such as through use of pass(1):

           PostUp = wg set %i private-key <(pass WireGuard/private-keys/%i)
```