### PR TITLE
use getpass to get user

### DIFF
--- a/wgnetns/main.py
+++ b/wgnetns/main.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+import getpass
 
 try:
     import yaml
@@ -92,7 +93,7 @@ def cli(args):
         data = json.loads(output)
         print('\n'.join(item['name'] for item in data))
     elif opts.action == 'switch':
-        os.execvp('sudo', ['ip', 'ip', 'netns', 'exec', opts.netns, 'sudo', '-u', os.getlogin(), '-D', Path.cwd().as_posix(), os.environ['SHELL'], '-i'])
+        os.execvp('sudo', ['ip', 'ip', 'netns', 'exec', opts.netns, 'sudo', '-u', getpass.getuser(), '-D', Path.cwd().as_posix(), os.environ['SHELL'], '-i'])
     else:
         raise RuntimeError('congratulations, you reached unreachable code')
 


### PR DESCRIPTION
os.getlogin() does not seem to work in all cases, however getpass.getuser() does.

As per https://docs.python.org/3/library/os.html#os.getlogin:
> For most purposes, it is more useful to use [getpass.getuser()](https://docs.python.org/3/library/getpass.html#getpass.getuser) since the latter checks the environment variables LOGNAME or USERNAME to find out who the user is, and falls back to pwd.getpwuid(os.getuid())[0] to get the login name of the current real user id.

Example:
```
$ sudo python
Python 3.11.3 (main, May 16 2023, 12:21:43) [GCC 12.2.1 20230428] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.getlogin()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
FileNotFoundError: [Errno 2] No such file or directory
>>> import getpass
>>> getpass.getuser()
'root'
```