### PR TITLE
Fix "error: Expecting value: line 1 column 1 (char 0) (JSONDecodeError)"

### DIFF
--- a/wgnetns/main.py
+++ b/wgnetns/main.py
@@ -90,6 +90,8 @@ def cli(args):
         namespace.teardown(check=not opts.force)
     elif opts.action == 'list':
         output = ip('-json', 'netns', capture=True)
+        if not output:
+            return
         data = json.loads(output)
         print('\n'.join(item['name'] for item in data))
     elif opts.action == 'switch':


### PR DESCRIPTION
This patch fixes the crash which happens during execution of `wg-netns list`. The crash happens if nothing else from `wg-netns` is executed on machine yet, i.e., after the reboot. In that case, `ip -json netns` returns an empty string, not `[]`, so we get an exception if we pass empty string into `json.loads()`.

```
$ export WG_VERBOSE=1
$ /home/user/.local/bin/wg-netns list
> ip -json netns
error: Expecting value: line 1 column 1 (char 0) (JSONDecodeError)
Traceback (most recent call last):
  File "/home/user/.local/bin/wg-netns", line 391, in <module>
    main()
  File "/home/user/.local/bin/wg-netns", line 27, in main
    cli(sys.argv[1:])
  File "/home/user/.local/bin/wg-netns", line 93, in cli
    data = json.loads(output)
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```